### PR TITLE
redirect to GreenBlock screen after updating tree

### DIFF
--- a/src/screens/TreeSubmission/screens/SubmitTree/SubmitTree.tsx
+++ b/src/screens/TreeSubmission/screens/SubmitTree/SubmitTree.tsx
@@ -242,8 +242,8 @@ function SubmitTree(props: Props) {
         });
         navigation.dispatch(
           CommonActions.reset({
-            index: 1,
-            routes: [{name: Routes.VerifiedProfileTab}, {name: Routes.GreenBlock, params: {filter: TreeFilter.Temp}}],
+            index: 0,
+            routes: [{name: Routes.GreenBlock, params: {filter: TreeFilter.Temp}}],
           }),
         );
       } else {


### PR DESCRIPTION
After updating the tree, I found an issue in tree submission, it didn't redirect to the Green lock screen, I fixed it.